### PR TITLE
Log all the data in the scope of parent run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added sample support for [TemplatedConfigLoader](https://kedro.readthedocs.io/en/latest/kedro.config.TemplatedConfigLoader.html)
+- MLFlow support updated to not use nested runs.
 
 ## [0.1.9] - 2021-01-08
 

--- a/kedro_kubeflow/hooks.py
+++ b/kedro_kubeflow/hooks.py
@@ -1,4 +1,3 @@
-
 from os import getenv
 from typing import Iterable
 

--- a/kedro_kubeflow/hooks.py
+++ b/kedro_kubeflow/hooks.py
@@ -1,40 +1,9 @@
-import os
+
 from os import getenv
-from typing import Any, Dict, Iterable
+from typing import Iterable
 
 from kedro.config import ConfigLoader, TemplatedConfigLoader
-from kedro.framework.context import load_context
 from kedro.framework.hooks import hook_impl
-from kedro.io import DataCatalog
-from kedro.pipeline import Pipeline
-
-from .utils import is_mlflow_enabled
-
-
-class MLFlowActivateParentHook:
-    @hook_impl
-    def before_pipeline_run(
-        self,
-        run_params: Dict[str, Any],
-        pipeline: Pipeline,
-        catalog: DataCatalog,
-    ) -> None:
-
-        if not is_mlflow_enabled():
-            return
-
-        import mlflow
-        from kedro_mlflow.framework.context import get_mlflow_config
-
-        context = load_context(
-            project_path=run_params["project_path"],
-            env=run_params["env"],
-            extra_params=run_params["extra_params"],
-        )
-        mlflow_conf = get_mlflow_config(context)
-        mlflow_conf.setup(context)
-
-        mlflow.start_run(run_id=os.getenv("MLFLOW_PARENT_ID"))
 
 
 class RegisterTemplatedConfigLoaderHook:
@@ -53,7 +22,5 @@ class RegisterTemplatedConfigLoaderHook:
             },
         )
 
-
-mlflow_activate_parent_run = MLFlowActivateParentHook()
 
 register_templated_config_loader = RegisterTemplatedConfigLoaderHook()

--- a/kedro_kubeflow/kfpclient.py
+++ b/kedro_kubeflow/kfpclient.py
@@ -168,7 +168,7 @@ class KubeflowClient(object):
                 )
                 env.append(
                     V1EnvVar(
-                        name="MLFLOW_PARENT_ID",
+                        name="MLFLOW_RUN_ID",
                         value=kfp_ops["mlflow-start-run"].output,
                     )
                 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
             "kubeflow = kedro_kubeflow.plugin:commands"
         ],
         "kedro.hooks": [
-            "kubeflow_mlflow_hook = kedro_kubeflow.hooks:mlflow_activate_parent_run",
             "kubeflow_cfg_hook = kedro_kubeflow.hooks:register_templated_config_loader",
         ],
     },

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -521,7 +521,7 @@ class TestKubeflowClient(unittest.TestCase):
         ]
         for node_name in ["node1", "node2"]:
             env = dsl_pipeline.ops[node_name].container.env
-            assert env[1].name == "MLFLOW_PARENT_ID"
+            assert env[1].name == "MLFLOW_RUN_ID"
             assert (
                 env[1].value
                 == "{{pipelineparam:op=mlflow-start-run;name=mlflow_run_id}}"


### PR DESCRIPTION
#### Description

MLFLOW_RUN_ID param is set gobally to ensure all the data is logged on one run

Resolves #23 

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
