### PR TITLE
KFPClient adjusted to new config, ability to skip volume init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added sample support for [TemplatedConfigLoader](https://kedro.readthedocs.io/en/latest/kedro.config.TemplatedConfigLoader.html)
 - MLFlow support updated to not use nested runs.
 - Simple configuration validation added.
+- Volume init step is now optional (useful, if there is raw data in the image)
 
 ## [0.1.9] - 2021-01-08
 

--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ run_config:
     storageclass: # default
     size: 1Gi
     access_modes: [ReadWriteOnce]
+    skip_init: False
 ```

--- a/kedro_kubeflow/config.py
+++ b/kedro_kubeflow/config.py
@@ -14,6 +14,7 @@ run_config:
     storageclass: # default
     #size: 1Gi
     #access_modes: [ReadWriteOnce]
+    #skip_init: False
 """
 
 
@@ -42,7 +43,7 @@ class Config(object):
 class VolumeConfig(Config):
     @property
     def storageclass(self):
-        return self._get_or_fail("storageclass")
+        return self._get_or_default("storageclass", None)
 
     @property
     def size(self):
@@ -51,6 +52,10 @@ class VolumeConfig(Config):
     @property
     def access_modes(self):
         return self._get_or_default("access_modes", "[ReadWriteMany]")
+
+    @property
+    def skip_init(self):
+        return self._get_or_default("skip_init", False)
 
     def _get_prefix(self):
         return "run_config.volume."
@@ -75,7 +80,7 @@ class RunConfig(Config):
 
     @property
     def volume(self):
-        cfg = self._get_or_fail("volume")
+        cfg = self._get_or_default("volume", None)
         return VolumeConfig(cfg)
 
     @property

--- a/kedro_kubeflow/config.py
+++ b/kedro_kubeflow/config.py
@@ -23,7 +23,7 @@ class Config(object):
         self._raw = raw
 
     def _get_or_default(self, prop, default):
-        return self._raw[prop] if prop in self._raw.keys() else default
+        return self._raw.get(prop, default)
 
     def _get_or_fail(self, prop):
         if prop in self._raw.keys():
@@ -51,7 +51,7 @@ class VolumeConfig(Config):
 
     @property
     def access_modes(self):
-        return self._get_or_default("access_modes", "[ReadWriteMany]")
+        return self._get_or_default("access_modes", ["ReadWriteMany"])
 
     @property
     def skip_init(self):
@@ -80,8 +80,11 @@ class RunConfig(Config):
 
     @property
     def volume(self):
-        cfg = self._get_or_default("volume", None)
-        return VolumeConfig(cfg)
+        if "volume" in self._raw.keys():
+            cfg = self._get_or_fail("volume")
+            return VolumeConfig(cfg)
+        else:
+            return None
 
     @property
     def wait_for_completion(self):

--- a/kedro_kubeflow/context_helper.py
+++ b/kedro_kubeflow/context_helper.py
@@ -53,7 +53,7 @@ class ContextHelper16(ContextHelper):
 
     @property
     def project_name(self):
-        return self.get_context(self._metadata, self._env).project_name
+        return self.context.project_name
 
     @property
     def context(self):

--- a/kedro_kubeflow/kfpclient.py
+++ b/kedro_kubeflow/kfpclient.py
@@ -25,12 +25,12 @@ class KubeflowClient(object):
 
     def __init__(self, config, project_name, context):
         token = self.obtain_id_token()
-        self.host = config["host"]
+        self.host = config.host
         self.client = Client(self.host, existing_token=token)
         self.project_name = project_name
         self.context = context
         dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
-        self.volume_meta = config.get("run_config", {}).get("volume")
+        self.volume_meta = config.run_config.volume
 
     def list_pipelines(self):
         pipelines = self.client.list_pipelines(page_size=30).pipelines
@@ -115,29 +115,33 @@ class KubeflowClient(object):
             vop = dsl.VolumeOp(
                 name="data-volume-create",
                 resource_name="data-volume",
-                size=self.volume_meta.get("size", "1Gi"),
-                modes=self.volume_meta.get("access_modes", ["ReadWriteMany"]),
-                storage_class=self.volume_meta.get("storage_class"),
+                size=self.volume_meta.size,
+                modes=self.volume_meta.access_modes,
+                storage_class=self.volume_meta.storageclass,
             )
-            volume_init = dsl.ContainerOp(
-                name="data-volume-init",
-                image=image,
-                command=["sh", "-c"],
-                arguments=[
-                    " ".join(
-                        [
-                            "cp",
-                            "--verbose",
-                            "-r",
-                            "/home/kedro/data/*",
-                            "/home/kedro/datavolume",
-                        ]
-                    )
-                ],
-                pvolumes={"/home/kedro/datavolume": vop.volume},
-            )
-            volume_init.container.set_image_pull_policy(image_pull_policy)
-            return {"/home/kedro/data": volume_init.pvolume}
+            if self.volume_meta.skip_init:
+                print("SKIP")
+                return {"/home/kedro/data": vop.volume}
+            else:
+                volume_init = dsl.ContainerOp(
+                    name="data-volume-init",
+                    image=image,
+                    command=["sh", "-c"],
+                    arguments=[
+                        " ".join(
+                            [
+                                "cp",
+                                "--verbose",
+                                "-r",
+                                "/home/kedro/data/*",
+                                "/home/kedro/datavolume",
+                            ]
+                        )
+                    ],
+                    pvolumes={"/home/kedro/datavolume": vop.volume},
+                )
+                volume_init.container.set_image_pull_policy(image_pull_policy)
+                return {"/home/kedro/data": volume_init.pvolume}
 
         def _build_kfp_ops(
             node_dependencies: Dict[Node, Set[Node]], node_volumes: Dict

--- a/kedro_kubeflow/kfpclient.py
+++ b/kedro_kubeflow/kfpclient.py
@@ -120,7 +120,6 @@ class KubeflowClient(object):
                 storage_class=self.volume_meta.storageclass,
             )
             if self.volume_meta.skip_init:
-                print("SKIP")
                 return {"/home/kedro/data": vop.volume}
             else:
                 volume_init = dsl.ContainerOp(

--- a/kedro_kubeflow/plugin.py
+++ b/kedro_kubeflow/plugin.py
@@ -175,7 +175,6 @@ def init(ctx, kfp_url: str):
     sample_config = PluginConfig.sample_config(
         url=kfp_url, image=image, project_name=context_helper.project_name
     )
-
     config_path = Path.cwd().joinpath("conf/base/kubeflow.yaml")
     with open(config_path, "w") as f:
         f.write(sample_config)


### PR DESCRIPTION
#### Description

* KFP Client was adjusted to the new object-like configuration
* Ability to skip volume init using `skip-init` flag in the config file (in case there is no raw data in the image)

Resolves #24

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
