### PR TITLE
Init calls fixed

### DIFF
--- a/kedro_kubeflow/config.py
+++ b/kedro_kubeflow/config.py
@@ -106,4 +106,4 @@ class PluginConfig(Config):
 
     @staticmethod
     def sample_config(**kwargs):
-        return DEFAULT_CONFIG_TEMPLATE.format(kwargs)
+        return DEFAULT_CONFIG_TEMPLATE.format(**kwargs)

--- a/kedro_kubeflow/plugin.py
+++ b/kedro_kubeflow/plugin.py
@@ -171,9 +171,11 @@ def schedule(ctx, experiment_name: str, cron_expression: str):
 def init(ctx, kfp_url: str):
     """Initializes configuration for the plugin"""
     context_helper = ctx.obj["context_helper"]
-    image = context_helper.project_path.name  # default from kedro-docker
+    image = (
+        context_helper.context.project_path.name
+    )  # default from kedro-docker
     sample_config = PluginConfig.sample_config(
-        url=kfp_url, image=image, project_name=context_helper.project_name
+        url=kfp_url, image=image, project=context_helper.project_name
     )
     config_path = Path.cwd().joinpath("conf/base/kubeflow.yaml")
     with open(config_path, "w") as f:


### PR DESCRIPTION
#### Description

Fixes the following issues:

```
$ kedro kubeflow init URL
...
  File "/home/mario/kedro/venv/lib/python3.8/site-packages/kedro_kubeflow/plugin.py", line 174, in init
    image = context_helper.project_path.name  # default from kedro-docker
AttributeError: 'ContextHelper16' object has no attribute 'project_path'
```

```
$ kedro kubeflow init URL
  File "/home/mario/kedro/venv/lib/python3.8/site-packages/kedro_kubeflow/plugin.py", line 176, in init
    sample_config = PluginConfig.sample_config(
  File "/home/mario/kedro/venv/lib/python3.8/site-packages/kedro_kubeflow/config.py", line 109, in sample_config
    return DEFAULT_CONFIG_TEMPLATE.format(kwargs)
KeyError: 'url'
```

```
$ kedro kubeflow init URL
...
  File "/home/mario/kedro/venv/lib/python3.8/site-packages/kedro_kubeflow/plugin.py", line 176, in init
    sample_config = PluginConfig.sample_config(
  File "/home/mario/kedro/venv/lib/python3.8/site-packages/kedro_kubeflow/config.py", line 109, in sample_config
    return DEFAULT_CONFIG_TEMPLATE.format(**kwargs)
KeyError: 'project'
```

##### PR Checklist
- [ ] Tests added
- [ ] [Changelog](CHANGELOG.md) updated 
