### PR TITLE
Improved Vertex scheduling: removal of old jobs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+- repo: https://github.com/pycqa/isort
+  rev: 5.5.4
   hooks:
   - id: isort
+    args: ["--profile", "black", "--line-length=79"]
 - repo: https://github.com/psf/black
   rev: stable
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Improved Vertex scheduling: removal of stale schedules
+
 ## [0.4.1] - 2021-08-18
 
 -   Passing Kedro environment and pipeline name in Vertex nodes

--- a/kedro_kubeflow/vertex_ai/generator.py
+++ b/kedro_kubeflow/vertex_ai/generator.py
@@ -40,6 +40,12 @@ class PipelineGenerator:
         self.run_config = config.run_config
         self.catalog = context.config_loader.get("catalog*")
 
+    def get_pipeline_name(self):
+        """
+        Returns Vertex-compatible pipeline name
+        """
+        return self.project_name.lower().replace(" ", "-")
+
     def generate_pipeline(self, pipeline, image, image_pull_policy, token):
         """
         This method return @dsl.pipeline annotated function that contains
@@ -58,7 +64,7 @@ class PipelineGenerator:
                 kfp_ops[name].after(kfp_ops[dependency_name])
 
         @dsl.pipeline(
-            name=self.project_name.lower().replace(" ", "-"),
+            name=self.get_pipeline_name(),
             description=self.run_config.description,
         )
         def convert_kedro_pipeline_to_kfp() -> None:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ EXTRA_REQUIRE = {
         "recommonmark==0.7.1",
         "sphinx_rtd_theme==0.5.1",
     ],
+    "vertexai": [
+        "google-cloud-scheduler>=2.3.2",
+    ],
 }
 
 setup(

--- a/tests/test_vertex_ai_client.py
+++ b/tests/test_vertex_ai_client.py
@@ -117,13 +117,11 @@ class TestKubeflowClient(unittest.TestCase):
             )
 
             ai_client.create_schedule_from_job_spec.assert_called_once()
-            schedule_args = ai_client.create_schedule_from_job_spec.call_args
-            assert schedule_args.kwargs["time_zone"] == "Etc/UTC"
-            assert schedule_args.kwargs["enable_caching"] is False
-            assert schedule_args.kwargs["schedule"] == "0 0 12 * *"
-            assert (
-                schedule_args.kwargs["pipeline_root"] == "gs://BUCKET/PREFIX"
-            )
+            args, kwargs = ai_client.create_schedule_from_job_spec.call_args
+            assert kwargs["time_zone"] == "Etc/UTC"
+            assert kwargs["enable_caching"] is False
+            assert kwargs["schedule"] == "0 0 12 * *"
+            assert kwargs["pipeline_root"] == "gs://BUCKET/PREFIX"
 
     def test_should_remove_old_schedule(self):
         def mock_job(job_name, pipeline_name=None):
@@ -181,8 +179,11 @@ class TestKubeflowClient(unittest.TestCase):
             # then
             ai_client.create_schedule_from_job_spec.assert_called_once()
             self.cloud_scheduler_client_mock.delete_job.assert_called_once()
-            delete_args = self.cloud_scheduler_client_mock.delete_job.call_args
+            (
+                args,
+                kwargs,
+            ) = self.cloud_scheduler_client_mock.delete_job.call_args
             assert (
-                delete_args.kwargs["name"]
+                kwargs["name"]
                 == "projects/.../locations/.../jobs/pipeline_pipeline_def"
             )

--- a/tests/test_vertex_ai_client.py
+++ b/tests/test_vertex_ai_client.py
@@ -3,13 +3,25 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from kedro_kubeflow.config import PluginConfig
 from kedro_kubeflow.utils import strip_margin
 from kedro_kubeflow.vertex_ai.client import VertexAIPipelinesClient
 
 
 class TestKubeflowClient(unittest.TestCase):
-    def create_client(self):
-        return VertexAIPipelinesClient(MagicMock(), MagicMock(), MagicMock())
+    @patch("kedro_kubeflow.vertex_ai.client.CloudSchedulerClient")
+    def create_client(self, cloud_scheduler_client_mock):
+        self.cloud_scheduler_client_mock = (
+            cloud_scheduler_client_mock.return_value
+        )
+        config = PluginConfig(
+            {
+                "project_id": "PROJECT_ID",
+                "region": "REGION",
+                "run_config": {"image": "IMAGE", "root": "BUCKET/PREFIX"},
+            }
+        )
+        return VertexAIPipelinesClient(config, MagicMock(), MagicMock())
 
     def test_compile(self):
         with patch(
@@ -101,7 +113,76 @@ class TestKubeflowClient(unittest.TestCase):
 
             client_under_test = self.create_client()
             client_under_test.schedule(
-                MagicMock("pipeline"), "image", "0 0 12 * *", "test-run"
+                MagicMock("pipeline"), None, None, "0 0 12 * *"
             )
 
             ai_client.create_schedule_from_job_spec.assert_called_once()
+            schedule_args = ai_client.create_schedule_from_job_spec.call_args
+            assert schedule_args.kwargs["time_zone"] == "Etc/UTC"
+            assert schedule_args.kwargs["enable_caching"] is False
+            assert schedule_args.kwargs["schedule"] == "0 0 12 * *"
+            assert (
+                schedule_args.kwargs["pipeline_root"] == "gs://BUCKET/PREFIX"
+            )
+
+    def test_should_remove_old_schedule(self):
+        def mock_job(job_name, pipeline_name=None):
+            if pipeline_name:
+                body = (
+                    '{"pipelineSpec": {"pipelineInfo": {"name": "'
+                    + pipeline_name
+                    + '"}}}'
+                )
+            else:
+                body = ""
+            return type(
+                "obj",
+                (object,),
+                {
+                    "schedule": "* * * * *",
+                    "name": job_name,
+                    "http_target": type("obj", (object,), {"body": body}),
+                },
+            )
+
+        with patch(
+            "kedro_kubeflow.vertex_ai.client.PipelineGenerator"
+        ) as generator, patch(
+            "kedro_kubeflow.vertex_ai.client.AIPlatformClient"
+        ) as AIPlatformClient, patch(
+            "kfp.v2.compiler.Compiler"
+        ):
+            # given
+            ai_client = AIPlatformClient.return_value
+            client_under_test = self.create_client()
+            generator.return_value.get_pipeline_name.return_value = (
+                "unittest-pipeline"
+            )
+            self.cloud_scheduler_client_mock.list_jobs.return_value = [
+                # not removed (some other job)
+                mock_job(job_name="some-job"),
+                # not removed (some other pipeline)
+                mock_job(
+                    job_name="projects/.../locations/.../jobs/pipeline_pipeline_abc",
+                    pipeline_name="some-other-pipeline",
+                ),
+                # removed
+                mock_job(
+                    job_name="projects/.../locations/.../jobs/pipeline_pipeline_def",
+                    pipeline_name="unittest-pipeline",
+                ),
+            ]
+
+            # when
+            client_under_test.schedule(
+                MagicMock("pipeline"), None, None, "0 0 12 * *"
+            )
+
+            # then
+            ai_client.create_schedule_from_job_spec.assert_called_once()
+            self.cloud_scheduler_client_mock.delete_job.assert_called_once()
+            delete_args = self.cloud_scheduler_client_mock.delete_job.call_args
+            assert (
+                delete_args.kwargs["name"]
+                == "projects/.../locations/.../jobs/pipeline_pipeline_def"
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ pip_version =
 extras = 
     mlflow
     tests
+    vertexai
 commands=
     python -m pytest --cov kedro_kubeflow --cov-report xml --cov-report term-missing --ignore=venv
 


### PR DESCRIPTION
#### Description

This PR adds a functionality to remove old schedules from vertex before adding a new one, so `kedro kubeflow -e vertex schedule` can be plugged in CI/CD process

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
