### PR TITLE
Passing Kedro env to the steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Kedro environment used by `kedro kubeflow` invocation is passed to the steps
+
 ## [0.4.2] - 2021-08-19
 
 -   Improved Vertex scheduling: removal of stale schedules

--- a/kedro_kubeflow/generator.py
+++ b/kedro_kubeflow/generator.py
@@ -138,6 +138,8 @@ class PipelineGenerator(object):
                     command=["kedro"],
                     arguments=[
                         "kubeflow",
+                        "--env",
+                        self.context.env,
                         "mlflow-start",
                         dsl.RUN_ID_PLACEHOLDER,
                     ],
@@ -176,6 +178,8 @@ class PipelineGenerator(object):
                     command=["kedro"],
                     arguments=[
                         "run",
+                        "--env",
+                        self.context.env,
                         "--params",
                         params,
                         "--pipeline",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -149,6 +149,8 @@ class TestGenerator(unittest.TestCase):
         assert init_step.image == "unittest-image"
         assert init_step.args == [
             "kubeflow",
+            "--env",
+            "unittests",
             "mlflow-start",
             "{{workflow.uid}}",
         ]
@@ -201,6 +203,8 @@ class TestGenerator(unittest.TestCase):
             args = dsl_pipeline.ops[node_name].container.args
             assert args == [
                 "run",
+                "--env",
+                "unittests",
                 "--params",
                 "param1:{{pipelineparam:op=;name=param1}},"
                 "param2:{{pipelineparam:op=;name=param2}}",
@@ -312,6 +316,7 @@ class TestGenerator(unittest.TestCase):
             "obj",
             (object,),
             {
+                "env": "unittests",
                 "params": params,
                 "config_loader": config_loader,
                 "pipelines": {


### PR DESCRIPTION
#### Description

Kedro environment is now included in the steps invocation (similarly like it's done in `kedro-airflow-k8s`), so users can have different configuration (in my case different catalog) for local vs kubeflow execution.

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
