### PR TITLE
Ability to skip artifacts registration in Kubeflow Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 -   Kedro environment used by `kedro kubeflow` invocation is passed to the steps
+-   A flag to skip steps output artifacts registration in Kubeflow Metadata
 
 ## [0.4.2] - 2021-08-19
 

--- a/kedro_kubeflow/config.py
+++ b/kedro_kubeflow/config.py
@@ -40,6 +40,11 @@ run_config:
   # See https://en.wikipedia.org/wiki/ISO_8601 in section 'Duration'
   #max_cache_staleness: P0D
 
+  # Set to false to disable kfp artifacts exposal
+  # This setting can be useful if you don't want to store
+  # intermediate results in the MLMD
+  #expose_kedro_outputs_as_kfp_artifacts: True
+
   # Optional volume specification (only for non vertex-ai)
   volume:
 
@@ -194,6 +199,12 @@ class RunConfig(Config):
     @property
     def wait_for_completion(self):
         return bool(self._get_or_default("wait_for_completion", False))
+
+    @property
+    def expose_kedro_outputs_as_kfp_artifacts(self):
+        return bool(
+            self._get_or_default("expose_kedro_outputs_as_kfp_artifacts", True)
+        )
 
     @property
     def max_cache_staleness(self):

--- a/kedro_kubeflow/config.py
+++ b/kedro_kubeflow/config.py
@@ -43,7 +43,7 @@ run_config:
   # Set to false to disable kfp artifacts exposal
   # This setting can be useful if you don't want to store
   # intermediate results in the MLMD
-  #expose_kedro_outputs_as_kfp_artifacts: True
+  #store_kedro_outputs_as_kfp_artifacts: True
 
   # Optional volume specification (only for non vertex-ai)
   volume:
@@ -201,9 +201,9 @@ class RunConfig(Config):
         return bool(self._get_or_default("wait_for_completion", False))
 
     @property
-    def expose_kedro_outputs_as_kfp_artifacts(self):
+    def store_kedro_outputs_as_kfp_artifacts(self):
         return bool(
-            self._get_or_default("expose_kedro_outputs_as_kfp_artifacts", True)
+            self._get_or_default("store_kedro_outputs_as_kfp_artifacts", True)
         )
 
     @property

--- a/kedro_kubeflow/generator.py
+++ b/kedro_kubeflow/generator.py
@@ -195,7 +195,7 @@ class PipelineGenerator(object):
                         for output in node.outputs
                         if output in self.catalog
                         and "filepath" in self.catalog[output]
-                        and self.run_config.expose_kedro_outputs_as_kfp_artifacts
+                        and self.run_config.store_kedro_outputs_as_kfp_artifacts
                     },
                 ),
                 image_pull_policy,

--- a/kedro_kubeflow/generator.py
+++ b/kedro_kubeflow/generator.py
@@ -195,6 +195,7 @@ class PipelineGenerator(object):
                         for output in node.outputs
                         if output in self.catalog
                         and "filepath" in self.catalog[output]
+                        and self.run_config.expose_kedro_outputs_as_kfp_artifacts
                     },
                 ),
                 image_pull_policy,

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ INSTALL_REQUIRES = [
     "tabulate>=0.8.7",
     "semver~=2.10",
     "google-auth<2.0dev",
+    "protobuf<3.18.0",
 ]
 
 # Dev Requirements

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -303,7 +303,7 @@ class TestGenerator(unittest.TestCase):
                     "filepath": "data/02_intermediate/b.csv",
                 }
             },
-            config={"expose_kedro_outputs_as_kfp_artifacts": False},
+            config={"store_kedro_outputs_as_kfp_artifacts": False},
         )
 
         # when

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -294,6 +294,29 @@ class TestGenerator(unittest.TestCase):
         outputs2 = dsl_pipeline.ops["node2"].file_outputs
         assert len(outputs2) == 0  # output "C" is missing in the catalog
 
+    def test_should_skip_artifact_registration_if_requested(self):
+        # given
+        self.create_generator(
+            catalog={
+                "B": {
+                    "type": "pandas.CSVDataSet",
+                    "filepath": "data/02_intermediate/b.csv",
+                }
+            },
+            config={"expose_kedro_outputs_as_kfp_artifacts": False},
+        )
+
+        # when
+        pipeline = self.generator_under_test.generate_pipeline(
+            "pipeline", "unittest-image", "Always"
+        )
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            pipeline()
+
+        # then
+        outputs1 = dsl_pipeline.ops["node1"].file_outputs
+        assert len(outputs1) == 0
+
     def test_should_skip_volume_removal_if_requested(self):
         # given
         self.create_generator(config={"volume": {"keep": True}})


### PR DESCRIPTION
#### Description

If the pipeline has a lot of steps, their output can quickly fill Minio storage. This PR introduces an option to skip the automatic kedro outputs registration. If user wishes some artifact to be stored in the long term, it can be exposed as Mlflow artifact.

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
