### PR TITLE
Change default environment

### DIFF
--- a/kedro_kubeflow/cli.py
+++ b/kedro_kubeflow/cli.py
@@ -22,7 +22,7 @@ def commands():
     name="kubeflow", context_settings=dict(help_option_names=["-h", "--help"])
 )
 @click.option(
-    "-e", "--env", "env", type=str, default="base", help="Environment to use."
+    "-e", "--env", "env", type=str, default="local", help="Environment to use."
 )
 @click.pass_obj
 @click.pass_context


### PR DESCRIPTION
Change default environment to `local` to be coherent with Kedro:
> If no env option is specified, this will default to using the local environment to overwrite conf/base.
> _Source: https://kedro.readthedocs.io/en/stable/04_kedro_project_setup/02_configuration.html#additional-configuration-environments_

