### PR TITLE
Ability to set custom metworking configuration for vertex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Custom networking setup for Vertex AI pipelines run
+
 ## [0.4.3] - 2021-09-27
 
 -   Kedro environment used by `kedro kubeflow` invocation is passed to the steps

--- a/docs/source/03_getting_started/02_gcp.md
+++ b/docs/source/03_getting_started/02_gcp.md
@@ -77,6 +77,19 @@ run_config:
   root: vertex-ai-pipelines-accessible-gcs-bucket/pipelines-specific-path
 ```
 
+If the pipeline requires access to services that are not exposed to public internet, you need to configure [VPC peering between Vertex internal network and VPC that hosts the internal service](https://cloud.google.com/vertex-ai/docs/general/vpc-peering) and then set the VPC identifier in the configuration. Optionally, you can add custom host aliases:
+
+```yaml
+run_config:
+  vertex_ai_networking:
+    vpc: projects/12345/global/networks/name-of-vpc
+    host_aliases:
+    - ip: 10.10.10.10
+      hostnames: ['mlflow.internal']
+    - ip: 10.10.20.20
+      hostnames: ['featurestore.internal']
+```
+
 ##### 2. Preparing environment variables
 
 There're the following specific environment variables required for the pipeline to run correctly:

--- a/kedro_kubeflow/config.py
+++ b/kedro_kubeflow/config.py
@@ -120,6 +120,17 @@ class Config(object):
         return self._raw == other._raw
 
 
+class VertexAiNetworkingConfig(Config):
+    @property
+    def vpc(self):
+        return self._get_or_default("vpc", None)
+
+    @property
+    def host_aliases(self):
+        aliases = self._get_or_default("host_aliases", [])
+        return {alias["ip"]: alias["hostnames"] for alias in aliases}
+
+
 class VolumeConfig(Config):
     @property
     def storageclass(self):
@@ -213,6 +224,12 @@ class RunConfig(Config):
     @property
     def ttl(self):
         return int(self._get_or_default("ttl", 3600 * 24 * 7))
+
+    @property
+    def vertex_ai_networking(self):
+        return VertexAiNetworkingConfig(
+            self._get_or_default("vertex_ai_networking", {})
+        )
 
     def _get_prefix(self):
         return "run_config."

--- a/kedro_kubeflow/vertex_ai/client.py
+++ b/kedro_kubeflow/vertex_ai/client.py
@@ -83,6 +83,7 @@ class VertexAIPipelinesClient:
                 pipeline_root=f"gs://{self.run_config.root}",
                 parameter_values={},
                 enable_caching=False,
+                network=self.run_config.vertex_ai_networking.vpc,
             )
             self.log.info("Run created %s", str(run))
             return run

--- a/kedro_kubeflow/vertex_ai/generator.py
+++ b/kedro_kubeflow/vertex_ai/generator.py
@@ -256,13 +256,8 @@ class PipelineGenerator:
     def _setup_volume_op(self, image):
         command = " ".join(
             [
-                f"mkdir --parents /gcs/{self._get_data_path()}",
-                "&&",
-                "cp",
-                "--verbose",
-                "-r",
-                "/home/kedro/data/*",
-                f"/gcs/{self._get_data_path()}",
+                f"mkdir --parents /gcs/{self._get_data_path()} &&",
+                f"cp -r /home/kedro/data/* /gcs/{self._get_data_path()}",
             ]
         )
         spec = ComponentSpec(

--- a/kedro_kubeflow/vertex_ai/generator.py
+++ b/kedro_kubeflow/vertex_ai/generator.py
@@ -253,12 +253,6 @@ class PipelineGenerator:
             f"{self.run_config.experiment_name}/{self.run_config.run_name}/data"
         )
 
-    def _get_mlruns_path(self):
-        return (
-            f"{self.run_config.root}/"
-            f"{self.run_config.experiment_name}/{self.run_config.run_name}/mlruns"
-        )
-
     def _setup_volume_op(self, image):
         command = " ".join(
             [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,12 +23,22 @@ run_config:
     keep: True
 """
 
+VERTEX_YAML = """
+host: vertex-ai-pipelines
+project_id: some-project
+region: some-region
+run_config:
+  vertex_ai_networking:
+    vpc: projects/some-project-id/global/networks/some-vpc-name
+    host_aliases:
+    - ip: 10.10.10.10
+      hostnames: ['mlflow.internal']
+"""
+
 
 class TestPluginConfig(unittest.TestCase):
     def test_plugin_config(self):
-
         cfg = PluginConfig(yaml.safe_load(CONFIG_YAML))
-
         assert cfg.host == "https://example.com"
         assert cfg.run_config.image == "gcr.io/project-image/test"
         assert cfg.run_config.image_pull_policy == "Always"
@@ -98,3 +108,18 @@ class TestPluginConfig(unittest.TestCase):
     def test_do_not_keep_volume_by_default(self):
         cfg = PluginConfig({"run_config": {"volume": {}}})
         assert cfg.run_config.volume.keep is False
+
+    def test_parse_vertex_ai_networking_config(self):
+        cfg = PluginConfig(yaml.safe_load(VERTEX_YAML))
+        assert (
+            cfg.run_config.vertex_ai_networking.vpc
+            == "projects/some-project-id/global/networks/some-vpc-name"
+        )
+        assert cfg.run_config.vertex_ai_networking.host_aliases == {
+            "10.10.10.10": ["mlflow.internal"]
+        }
+
+    def test_accept_default_vertex_ai_networking_config(self):
+        cfg = PluginConfig({"run_config": {}})
+        assert cfg.run_config.vertex_ai_networking.vpc is None
+        assert cfg.run_config.vertex_ai_networking.host_aliases == {}

--- a/tests/test_vertex_ai_client.py
+++ b/tests/test_vertex_ai_client.py
@@ -18,7 +18,11 @@ class TestKubeflowClient(unittest.TestCase):
             {
                 "project_id": "PROJECT_ID",
                 "region": "REGION",
-                "run_config": {"image": "IMAGE", "root": "BUCKET/PREFIX"},
+                "run_config": {
+                    "image": "IMAGE",
+                    "root": "BUCKET/PREFIX",
+                    "vertex_ai_networking": {"vpc": "my-vpc"},
+                },
             }
         )
         return VertexAIPipelinesClient(config, MagicMock(), MagicMock())
@@ -65,6 +69,8 @@ class TestKubeflowClient(unittest.TestCase):
             )
 
             assert run_mock == run
+            _, kwargs = ai_client.create_run_from_job_spec.call_args
+            assert kwargs["network"] == "my-vpc"
 
     def test_should_list_pipelines(self):
         with patch(


### PR DESCRIPTION
#### Description

This PR provides a support to set custom networking in Vertex AI pipelines. Vertex is a managed service and the steps run in Google-managed network, so in case to access internal (no-publicly-exposed) services, there is need to create VPC peering and configure it during pipeline run.

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
