### PR TITLE
Add `node_merge_strategy` config alongside with `full` strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Add `node_merge_strategy` alongside with `full` option to run a whole pipeline in one pod
+
 ## [0.4.4] - 2021-09-29
 
 -   Custom networking setup for Vertex AI pipelines run

--- a/kedro_kubeflow/cli.py
+++ b/kedro_kubeflow/cli.py
@@ -67,19 +67,11 @@ def list_pipelines(ctx):
     help="Namespace where pipeline experiment run should be deployed to. Not needed "
     "if provided experiment name already exists.",
 )
-@click.option(
-    "--one-pod",
-    help="Generate only one pod in Kubeflow for a pipeline",
-    is_flag=True,
-)
 @click.pass_context
-def run_once(
-    ctx, image: str, pipeline: str, experiment_namespace: str, one_pod: bool
-):
+def run_once(ctx, image: str, pipeline: str, experiment_namespace: str):
     """Deploy pipeline as a single run within given experiment.
     Config can be specified in kubeflow.yml as well."""
     context_helper = ctx.obj["context_helper"]
-    context_helper.one_pod_pipeline_generator = one_pod
     config = context_helper.config.run_config
 
     context_helper.kfp_client.run_once(
@@ -123,16 +115,10 @@ def ui(ctx) -> None:
     default="pipeline.yml",
     help="Pipeline YAML definition file.",
 )
-@click.option(
-    "--one-pod",
-    help="Generate only one pod in Kubeflow for a pipeline",
-    is_flag=True,
-)
 @click.pass_context
-def compile(ctx, image, pipeline, output, one_pod) -> None:
+def compile(ctx, image, pipeline, output) -> None:
     """Translates Kedro pipeline into YAML file with Kubeflow Pipeline definition"""
     context_helper = ctx.obj["context_helper"]
-    context_helper.one_pod_pipeline_generator = one_pod
     config = context_helper.config.run_config
 
     context_helper.kfp_client.compile(
@@ -158,16 +144,10 @@ def compile(ctx, image, pipeline, output, one_pod) -> None:
     help="Name of pipeline to upload",
     default="__default__",
 )
-@click.option(
-    "--one-pod",
-    help="Generate only one pod in Kubeflow for a pipeline",
-    is_flag=True,
-)
 @click.pass_context
-def upload_pipeline(ctx, image, pipeline, one_pod) -> None:
+def upload_pipeline(ctx, image, pipeline) -> None:
     """Uploads pipeline to Kubeflow server"""
     context_helper = ctx.obj["context_helper"]
-    context_helper.one_pod_pipeline_generator = one_pod
     config = context_helper.config.run_config
 
     context_helper.kfp_client.upload(

--- a/kedro_kubeflow/cli.py
+++ b/kedro_kubeflow/cli.py
@@ -67,11 +67,19 @@ def list_pipelines(ctx):
     help="Namespace where pipeline experiment run should be deployed to. Not needed "
     "if provided experiment name already exists.",
 )
+@click.option(
+    "--one-pod",
+    help="Generate only one pod in Kubeflow for a pipeline",
+    is_flag=True,
+)
 @click.pass_context
-def run_once(ctx, image: str, pipeline: str, experiment_namespace: str):
+def run_once(
+    ctx, image: str, pipeline: str, experiment_namespace: str, one_pod: bool
+):
     """Deploy pipeline as a single run within given experiment.
     Config can be specified in kubeflow.yml as well."""
     context_helper = ctx.obj["context_helper"]
+    context_helper.one_pod_pipeline_generator = one_pod
     config = context_helper.config.run_config
 
     context_helper.kfp_client.run_once(
@@ -115,10 +123,16 @@ def ui(ctx) -> None:
     default="pipeline.yml",
     help="Pipeline YAML definition file.",
 )
+@click.option(
+    "--one-pod",
+    help="Generate only one pod in Kubeflow for a pipeline",
+    is_flag=True,
+)
 @click.pass_context
-def compile(ctx, image, pipeline, output) -> None:
+def compile(ctx, image, pipeline, output, one_pod) -> None:
     """Translates Kedro pipeline into YAML file with Kubeflow Pipeline definition"""
     context_helper = ctx.obj["context_helper"]
+    context_helper.one_pod_pipeline_generator = one_pod
     config = context_helper.config.run_config
 
     context_helper.kfp_client.compile(
@@ -144,10 +158,16 @@ def compile(ctx, image, pipeline, output) -> None:
     help="Name of pipeline to upload",
     default="__default__",
 )
+@click.option(
+    "--one-pod",
+    help="Generate only one pod in Kubeflow for a pipeline",
+    is_flag=True,
+)
 @click.pass_context
-def upload_pipeline(ctx, image, pipeline) -> None:
+def upload_pipeline(ctx, image, pipeline, one_pod) -> None:
     """Uploads pipeline to Kubeflow server"""
     context_helper = ctx.obj["context_helper"]
+    context_helper.one_pod_pipeline_generator = one_pod
     config = context_helper.config.run_config
 
     context_helper.kfp_client.upload(

--- a/kedro_kubeflow/context_helper.py
+++ b/kedro_kubeflow/context_helper.py
@@ -11,17 +11,22 @@ class ContextHelper(object):
 
     CONFIG_FILE_PATTERN = "kubeflow*"
 
-    def __init__(
-        self,
-        metadata,
-        env,
-    ):
+    def __init__(self, metadata, env, one_pod_pipeline_generator):
         self._metadata = metadata
         self._env = env
+        self._one_pod_pipeline_generator = one_pod_pipeline_generator
 
     @property
     def project_name(self):
         return self._metadata.project_name
+
+    @property
+    def one_pod_pipeline_generator(self):
+        return self._one_pod_pipeline_generator
+
+    @one_pod_pipeline_generator.setter
+    def one_pod_pipeline_generator(self, value):
+        self._one_pod_pipeline_generator = value
 
     @property
     @lru_cache()
@@ -56,24 +61,16 @@ class ContextHelper(object):
                 self.config,
                 self.project_name,
                 self.context,
+                self.one_pod_pipeline_generator,
             )
 
     @staticmethod
-    def init(
-        metadata,
-        env,
-    ):
+    def init(metadata, env, one_pod_pipeline_generator=False):
         version = VersionInfo.parse(kedro_version)
         if version.match(">=0.17.0"):
-            return ContextHelper(
-                metadata,
-                env,
-            )
+            return ContextHelper(metadata, env, one_pod_pipeline_generator)
         else:
-            return ContextHelper16(
-                metadata,
-                env,
-            )
+            return ContextHelper16(metadata, env, one_pod_pipeline_generator)
 
 
 class ContextHelper16(ContextHelper):

--- a/kedro_kubeflow/context_helper.py
+++ b/kedro_kubeflow/context_helper.py
@@ -11,22 +11,13 @@ class ContextHelper(object):
 
     CONFIG_FILE_PATTERN = "kubeflow*"
 
-    def __init__(self, metadata, env, one_pod_pipeline_generator):
+    def __init__(self, metadata, env):
         self._metadata = metadata
         self._env = env
-        self._one_pod_pipeline_generator = one_pod_pipeline_generator
 
     @property
     def project_name(self):
         return self._metadata.project_name
-
-    @property
-    def one_pod_pipeline_generator(self):
-        return self._one_pod_pipeline_generator
-
-    @one_pod_pipeline_generator.setter
-    def one_pod_pipeline_generator(self, value):
-        self._one_pod_pipeline_generator = value
 
     @property
     @lru_cache()
@@ -61,16 +52,15 @@ class ContextHelper(object):
                 self.config,
                 self.project_name,
                 self.context,
-                self.one_pod_pipeline_generator,
             )
 
     @staticmethod
-    def init(metadata, env, one_pod_pipeline_generator=False):
+    def init(metadata, env):
         version = VersionInfo.parse(kedro_version)
         if version.match(">=0.17.0"):
-            return ContextHelper(metadata, env, one_pod_pipeline_generator)
+            return ContextHelper(metadata, env)
         else:
-            return ContextHelper16(metadata, env, one_pod_pipeline_generator)
+            return ContextHelper16(metadata, env)
 
 
 class ContextHelper16(ContextHelper):

--- a/kedro_kubeflow/generators/__init__.py
+++ b/kedro_kubeflow/generators/__init__.py
@@ -1,0 +1,1 @@
+"""kedro_kubeflow.generators"""

--- a/kedro_kubeflow/generators/one_pod_pipeline_generator.py
+++ b/kedro_kubeflow/generators/one_pod_pipeline_generator.py
@@ -1,0 +1,109 @@
+import logging
+import os
+from typing import Dict
+
+import kubernetes.client as k8s
+from kfp import dsl
+
+from ..auth import IAP_CLIENT_ID
+from ..utils import clean_name, is_mlflow_enabled
+from .utils import create_params, maybe_add_params
+
+
+class OnePodPipelineGenerator(object):
+    log = logging.getLogger(__name__)
+
+    def __init__(self, config, project_name, context):
+        self.project_name = project_name
+        self.context = context
+        dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
+        self.run_config = config.run_config
+        self.catalog = context.config_loader.get("catalog*")
+
+    def generate_pipeline(self, pipeline, image, image_pull_policy):
+        @dsl.pipeline(self.project_name, self.run_config.description)
+        @maybe_add_params(self.context.params)
+        def convert_kedro_pipeline_to_kfp() -> None:
+            dsl.get_pipeline_conf().set_ttl_seconds_after_finished(
+                self.run_config.ttl
+            )
+            kfp_ops = self._build_kfp_ops(pipeline, image, image_pull_policy)
+
+            for _, op in kfp_ops.items():
+                op.execution_options.caching_strategy.max_cache_staleness = (
+                    self.run_config.max_cache_staleness
+                )
+
+        return convert_kedro_pipeline_to_kfp
+
+    def _build_kfp_ops(
+        self,
+        pipeline,
+        image,
+        image_pull_policy,
+    ) -> Dict[str, dsl.ContainerOp]:
+        """Build kfp container graph from Kedro node dependencies."""
+        kfp_ops = {}
+
+        nodes_env = [
+            k8s.V1EnvVar(
+                name=IAP_CLIENT_ID, value=os.environ.get(IAP_CLIENT_ID, "")
+            )
+        ]
+
+        if is_mlflow_enabled():
+            print("MLFLOW enabled")
+            kfp_ops["mlflow-start-run"] = dsl.ContainerOp(
+                name="mlflow-start-run",
+                image=image,
+                command=["kedro"],
+                arguments=[
+                    "kubeflow",
+                    "--env",
+                    self.context.env,
+                    "mlflow-start",
+                    dsl.RUN_ID_PLACEHOLDER,
+                ],
+                container_kwargs={
+                    "env": nodes_env,
+                    "image_pull_policy": image_pull_policy,
+                },
+                file_outputs={"mlflow_run_id": "/tmp/mlflow_run_id"},
+            )
+
+            nodes_env.append(
+                k8s.V1EnvVar(
+                    "MLFLOW_RUN_ID", kfp_ops["mlflow-start-run"].output
+                )
+            )
+
+        kwargs = {"env": nodes_env, "image_pull_policy": image_pull_policy}
+        default_resources = self.run_config.resources.get_for("__default__")
+        if default_resources:
+            kwargs["resources"] = k8s.V1ResourceRequirements(
+                limits=default_resources, requests=default_resources
+            )
+
+        kfp_ops[self.project_name] = dsl.ContainerOp(
+            name=clean_name(pipeline),
+            image=image,
+            command=["kedro"],
+            arguments=[
+                "run",
+                "--env",
+                self.context.env,
+                "--params",
+                create_params(self.context.params.keys()),
+                "--pipeline",
+                pipeline,
+            ],
+            container_kwargs=kwargs,
+            file_outputs={
+                output: f"/home/kedro/{self.catalog[output]['filepath']}"
+                for output in self.catalog
+                if "filepath" in self.catalog[output]
+                and self.run_config.store_kedro_outputs_as_kfp_artifacts
+            },
+        )
+
+        return kfp_ops

--- a/kedro_kubeflow/generators/utils.py
+++ b/kedro_kubeflow/generators/utils.py
@@ -1,0 +1,28 @@
+from functools import wraps
+from inspect import Parameter, signature
+from typing import Iterable
+
+from kfp import dsl
+
+
+def maybe_add_params(kedro_parameters):
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f()
+
+        sig = signature(f)
+        new_params = (
+            Parameter(name, Parameter.KEYWORD_ONLY, default=default)
+            for name, default in kedro_parameters.items()
+        )
+        wrapper.__signature__ = sig.replace(parameters=new_params)
+        return wrapper
+
+    return decorator
+
+
+def create_params(param_keys: Iterable[str]) -> str:
+    return ",".join(
+        [f"{param}:{dsl.PipelineParam(param)}" for param in param_keys]
+    )

--- a/kedro_kubeflow/kfpclient.py
+++ b/kedro_kubeflow/kfpclient.py
@@ -7,8 +7,14 @@ from kfp import Client
 from kfp.compiler import Compiler
 from tabulate import tabulate
 
+from kedro_kubeflow.generators.one_pod_pipeline_generator import (
+    OnePodPipelineGenerator,
+)
+from kedro_kubeflow.generators.pod_per_node_pipeline_generator import (
+    PodPerNodePipelineGenerator,
+)
+
 from .auth import AuthHandler
-from .generator import PipelineGenerator
 from .utils import clean_name
 
 WAIT_TIMEOUT = 24 * 60 * 60
@@ -18,7 +24,7 @@ class KubeflowClient(object):
 
     log = logging.getLogger(__name__)
 
-    def __init__(self, config, project_name, context):
+    def __init__(self, config, project_name, context, one_pod_pipeline=False):
         client_params = {}
         token = AuthHandler().obtain_id_token()
         if token is not None:
@@ -35,7 +41,11 @@ class KubeflowClient(object):
 
         self.project_name = project_name
         self.pipeline_description = config.run_config.description
-        self.generator = PipelineGenerator(config, project_name, context)
+        self.generator = (
+            PodPerNodePipelineGenerator(config, project_name, context)
+            if not one_pod_pipeline
+            else OnePodPipelineGenerator(config, project_name, context)
+        )
 
     def list_pipelines(self):
         pipelines = self.client.list_pipelines(page_size=30).pipelines

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -8,7 +8,9 @@ import kfp
 from kedro.pipeline import Pipeline, node
 
 from kedro_kubeflow.config import PluginConfig
-from kedro_kubeflow.generator import PipelineGenerator
+from kedro_kubeflow.generators.pod_per_node_pipeline_generator import (
+    PodPerNodePipelineGenerator,
+)
 
 
 def identity(input1: str):
@@ -16,14 +18,6 @@ def identity(input1: str):
 
 
 class TestGenerator(unittest.TestCase):
-    def create_pipeline(self):
-        return Pipeline(
-            [
-                node(identity, "A", "B", name="node1"),
-                node(identity, "B", "C", name="node2"),
-            ]
-        )
-
     def test_support_modification_of_pull_policy(self):
         # given
         self.create_generator()
@@ -352,7 +346,7 @@ class TestGenerator(unittest.TestCase):
                 },
             },
         )
-        self.generator_under_test = PipelineGenerator(
+        self.generator_under_test = PodPerNodePipelineGenerator(
             PluginConfig({"host": "http://unittest", "run_config": config}),
             project_name,
             context,

--- a/tests/test_kfpclient.py
+++ b/tests/test_kfpclient.py
@@ -321,6 +321,22 @@ class TestKubeflowClient(unittest.TestCase):
         self.kfp_client_mock.pipeline_uploads.upload_pipeline.assert_not_called()
         self.kfp_client_mock.pipeline_uploads.upload_pipeline_version.assert_called()
 
+    @patch("kedro_kubeflow.kfpclient.Client")
+    def test_should_raise_error_if_invalid_node_merge_strategy(
+        self, kfp_client_mock
+    ):
+        with self.assertRaises(ValueError):
+            KubeflowClient(
+                PluginConfig(
+                    {
+                        "host": "http://unittest",
+                        "run_config": {"node_merge_strategy": "other"},
+                    }
+                ),
+                None,
+                None,
+            )
+
     @patch("kedro_kubeflow.kfpclient.PodPerNodePipelineGenerator")
     @patch("kedro_kubeflow.kfpclient.Client")
     def create_client(self, config, kfp_client_mock, pipeline_generator_mock):

--- a/tests/test_kfpclient.py
+++ b/tests/test_kfpclient.py
@@ -136,7 +136,7 @@ class TestKubeflowClient(unittest.TestCase):
                 assert "generateName: my-awesome-project-" in yamlfile.read()
 
     @patch("kedro_kubeflow.kfpclient.AuthHandler")
-    @patch("kedro_kubeflow.kfpclient.PipelineGenerator")
+    @patch("kedro_kubeflow.kfpclient.PodPerNodePipelineGenerator")
     @patch("kedro_kubeflow.kfpclient.Client")
     def test_should_use_jwt_token_in_kfp_client(
         self, kfp_client_mock, pipeline_generator_mock, auth_handler_mock
@@ -163,7 +163,7 @@ class TestKubeflowClient(unittest.TestCase):
         )
 
     @patch("kedro_kubeflow.kfpclient.AuthHandler")
-    @patch("kedro_kubeflow.kfpclient.PipelineGenerator")
+    @patch("kedro_kubeflow.kfpclient.PodPerNodePipelineGenerator")
     @patch("kedro_kubeflow.kfpclient.Client")
     def test_should_use_dex_session_in_kfp_client(
         self, kfp_client_mock, pipeline_generator_mock, auth_handler_mock
@@ -321,7 +321,7 @@ class TestKubeflowClient(unittest.TestCase):
         self.kfp_client_mock.pipeline_uploads.upload_pipeline.assert_not_called()
         self.kfp_client_mock.pipeline_uploads.upload_pipeline_version.assert_called()
 
-    @patch("kedro_kubeflow.kfpclient.PipelineGenerator")
+    @patch("kedro_kubeflow.kfpclient.PodPerNodePipelineGenerator")
     @patch("kedro_kubeflow.kfpclient.Client")
     def create_client(self, config, kfp_client_mock, pipeline_generator_mock):
         project_name = "my-awesome-project"

--- a/tests/test_one_pod_pipeline_generator.py
+++ b/tests/test_one_pod_pipeline_generator.py
@@ -1,0 +1,245 @@
+"""Test generator"""
+
+import unittest
+from inspect import signature
+from unittest.mock import MagicMock
+
+import kfp
+from kedro.pipeline import Pipeline, node
+
+from kedro_kubeflow.config import PluginConfig
+from kedro_kubeflow.generators.one_pod_pipeline_generator import (
+    OnePodPipelineGenerator,
+)
+
+
+def identity(input1: str):
+    return input1  # pragma: no cover
+
+
+class TestGenerator(unittest.TestCase):
+    def test_support_modification_of_pull_policy(self):
+        # given
+        self.create_generator()
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Never"
+            )()
+
+        # then
+        assert len(dsl_pipeline.ops) == 1
+        assert dsl_pipeline.ops["pipeline"].container.image == "unittest-image"
+        assert (
+            dsl_pipeline.ops["pipeline"].container.image_pull_policy == "Never"
+        )
+
+    def test_should_add_mlflow_init_step_if_enabled(self):
+        # given
+        self.create_generator()
+        self.mock_mlflow(True)
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )()
+
+        # then
+        assert len(dsl_pipeline.ops) == 2
+        init_step = dsl_pipeline.ops["mlflow-start-run"].container
+        assert init_step.image == "unittest-image"
+        assert init_step.args == [
+            "kubeflow",
+            "--env",
+            "unittests",
+            "mlflow-start",
+            "{{workflow.uid}}",
+        ]
+        env = dsl_pipeline.ops["pipeline"].container.env
+        assert env[1].name == "MLFLOW_RUN_ID"
+        assert (
+            env[1].value
+            == "{{pipelineparam:op=mlflow-start-run;name=mlflow_run_id}}"
+        )
+
+    def test_should_support_params_and_inject_them_to_the_nodes(self):
+        # given
+        self.create_generator(params={"param1": 0.3, "param2": 42})
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            pipeline = self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )
+            default_params = signature(pipeline).parameters
+            pipeline()
+
+        # then
+        assert len(default_params) == 2
+        assert default_params["param1"].default == 0.3
+        assert default_params["param2"].default == 42
+        args = dsl_pipeline.ops["pipeline"].container.args
+        assert args == [
+            "run",
+            "--env",
+            "unittests",
+            "--params",
+            "param1:{{pipelineparam:op=;name=param1}},"
+            "param2:{{pipelineparam:op=;name=param2}}",
+            "--pipeline",
+            "pipeline",
+        ]
+
+    def test_should_not_add_resources_spec_if_not_requested(self):
+        # given
+        self.create_generator(config={})
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )()
+
+        # then
+        assert dsl_pipeline.ops["pipeline"].container.resources is None
+
+    def test_should_add_resources_spec(self):
+        # given
+        self.create_generator(
+            config={
+                "resources": {
+                    "__default__": {"cpu": "100m", "memory": "8Gi"},
+                    "node1": {"cpu": "400m", "memory": "64Gi"},
+                }
+            }
+        )
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )()
+
+        # then
+        resources = dsl_pipeline.ops["pipeline"].container.resources
+        assert resources.limits == {"cpu": "100m", "memory": "8Gi"}
+        assert resources.requests == {"cpu": "100m", "memory": "8Gi"}
+
+    def test_should_set_description(self):
+        # given
+        self.create_generator(config={"description": "DESC"})
+
+        # when
+        pipeline = self.generator_under_test.generate_pipeline(
+            "pipeline", "unittest-image", "Never"
+        )
+
+        # then
+        assert pipeline._component_description == "DESC"
+
+    def test_artifact_registration(self):
+        # given
+        self.create_generator(
+            catalog={
+                "B": {
+                    "type": "pandas.CSVDataSet",
+                    "filepath": "data/02_intermediate/b.csv",
+                }
+            }
+        )
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )()
+
+        # then
+        assert dsl_pipeline.ops["pipeline"].file_outputs == {
+            "B": "/home/kedro/data/02_intermediate/b.csv"
+        }
+
+    def test_should_skip_artifact_registration_if_requested(self):
+        # given
+        self.create_generator(
+            catalog={
+                "B": {
+                    "type": "pandas.CSVDataSet",
+                    "filepath": "data/02_intermediate/b.csv",
+                }
+            },
+            config={"store_kedro_outputs_as_kfp_artifacts": False},
+        )
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )()
+
+        # then
+        assert dsl_pipeline.ops["pipeline"].file_outputs == {}
+
+    def test_should_skip_volume_removal_if_requested(self):
+        # given
+        self.create_generator(config={"volume": {"keep": True}})
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )()
+
+        # then
+        assert "schedule-volume-termination" not in dsl_pipeline.ops
+
+    def create_generator(self, config=None, params=None, catalog=None):
+        if config is None:
+            config = {}
+        if params is None:
+            params = {}
+        if catalog is None:
+            catalog = {}
+        config_loader = MagicMock()
+        config_loader.get.return_value = catalog
+        context = type(
+            "obj",
+            (object,),
+            {
+                "env": "unittests",
+                "params": params,
+                "config_loader": config_loader,
+                "pipelines": {
+                    "pipeline": Pipeline(
+                        [
+                            node(identity, "A", "B", name="node1"),
+                            node(identity, "B", "C", name="node2"),
+                        ]
+                    )
+                },
+            },
+        )
+        self.generator_under_test = OnePodPipelineGenerator(
+            config=PluginConfig(
+                {"host": "http://unittest", "run_config": config}
+            ),
+            project_name="my-awesome-project",
+            context=context,
+        )
+
+    def mock_mlflow(self, enabled=False):
+        def fakeimport(name, *args, **kw):
+            if not enabled and name == "mlflow":
+                raise ImportError
+            return self.realimport(name, *args, **kw)
+
+        __builtins__["__import__"] = fakeimport
+
+    def setUp(self):
+        self.realimport = __builtins__["__import__"]
+        self.mock_mlflow(False)
+
+    def tearDown(self):
+        __builtins__["__import__"] = self.realimport


### PR DESCRIPTION
#### Description

New `node_merge_strategy` configuration was added which allows to choose between different generators (code responsible for translating pipelines into target system).

Alongside with this property new `full` strategy was added which effectively merges all nodes from Kedro pipeline into one node in Kubeflow pipelines. This strategy mitigate potential performance issues with `none` strategy but at the cost of degraded user experience within Kubeflow UI: a graph is collapsed to one node.

Generator for Vertex AI wasn't in scope of this PR. It will be implemented separately.

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
