### PR TITLE
Passing all KEDRO_CONFIG_ env to the nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Passing all `KEDRO_CONFIG_` environment variables to the pipeline nodes
+
 ## [0.4.5] - 2021-12-22
 
 -   Add `node_merge_strategy` alongside with `full` option to run a whole pipeline in one pod

--- a/kedro_kubeflow/generators/one_pod_pipeline_generator.py
+++ b/kedro_kubeflow/generators/one_pod_pipeline_generator.py
@@ -1,12 +1,14 @@
 import logging
-import os
 
 import kubernetes.client as k8s
 from kfp import dsl
 
-from ..auth import IAP_CLIENT_ID
 from ..utils import clean_name
-from .utils import create_params, maybe_add_params
+from .utils import (
+    create_container_environment,
+    create_params,
+    maybe_add_params,
+)
 
 
 class OnePodPipelineGenerator(object):
@@ -37,11 +39,7 @@ class OnePodPipelineGenerator(object):
         image_pull_policy,
     ) -> dsl.ContainerOp:
         kwargs = {
-            "env": [
-                k8s.V1EnvVar(
-                    name=IAP_CLIENT_ID, value=os.environ.get(IAP_CLIENT_ID, "")
-                )
-            ],
+            "env": create_container_environment(),
             "image_pull_policy": image_pull_policy,
         }
         default_resources = self.run_config.resources.get_for("__default__")

--- a/kedro_kubeflow/generators/utils.py
+++ b/kedro_kubeflow/generators/utils.py
@@ -1,8 +1,12 @@
+import os
 from functools import wraps
 from inspect import Parameter, signature
 from typing import Iterable
 
+import kubernetes.client as k8s
 from kfp import dsl
+
+from ..auth import IAP_CLIENT_ID
 
 
 def maybe_add_params(kedro_parameters):
@@ -26,3 +30,16 @@ def create_params(param_keys: Iterable[str]) -> str:
     return ",".join(
         [f"{param}:{dsl.PipelineParam(param)}" for param in param_keys]
     )
+
+
+def create_container_environment():
+    env_vars = [
+        k8s.V1EnvVar(
+            name=IAP_CLIENT_ID, value=os.environ.get(IAP_CLIENT_ID, "")
+        )
+    ]
+    for key in os.environ.keys():
+        if key.startswith("KEDRO_CONFIG_"):
+            env_vars.append(k8s.V1EnvVar(name=key, value=os.environ[key]))
+
+    return env_vars


### PR DESCRIPTION
#### Description

In order to pass some additional runtime context to the pipeline (for example the commit id or branch name), this change extends the environment of the nodes by all `KEDRO_CONFIG_` prefixed values

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
