### PR TITLE
Pass `kubeflow_run_id` when full node merge strategy is chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Add `kubeflow_run_id` parameter when MLFlow is enabled and `full` node merge strategy is used
+
 ## [0.4.6] - 2021-12-23
 
 -   Passing all `KEDRO_CONFIG_` environment variables to the pipeline nodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Add `kubeflow_run_id` tag to MLFlow run when `full` node merge strategy is used
+
 ## [0.4.6] - 2021-12-23
 
 -   Passing all `KEDRO_CONFIG_` environment variables to the pipeline nodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
--   Add `kubeflow_run_id` parameter when MLFlow is enabled and `full` node merge strategy is used
-
 ## [0.4.6] - 2021-12-23
 
 -   Passing all `KEDRO_CONFIG_` environment variables to the pipeline nodes

--- a/kedro_kubeflow/generators/one_pod_pipeline_generator.py
+++ b/kedro_kubeflow/generators/one_pod_pipeline_generator.py
@@ -3,7 +3,7 @@ import logging
 import kubernetes.client as k8s
 from kfp import dsl
 
-from ..utils import clean_name, is_mlflow_enabled
+from ..utils import clean_name
 from .utils import (
     create_container_environment,
     create_params,
@@ -56,12 +56,7 @@ class OnePodPipelineGenerator(object):
                 "--env",
                 self.context.env,
                 "--params",
-                create_params(
-                    self.context.params.keys(),
-                    {"kubeflow_run_id": dsl.RUN_ID_PLACEHOLDER}
-                    if is_mlflow_enabled()
-                    else {},
-                ),
+                create_params(self.context.params.keys()),
                 "--pipeline",
                 pipeline,
             ],

--- a/kedro_kubeflow/generators/one_pod_pipeline_generator.py
+++ b/kedro_kubeflow/generators/one_pod_pipeline_generator.py
@@ -3,7 +3,7 @@ import logging
 import kubernetes.client as k8s
 from kfp import dsl
 
-from ..utils import clean_name
+from ..utils import clean_name, is_mlflow_enabled
 from .utils import (
     create_container_environment,
     create_params,
@@ -56,7 +56,12 @@ class OnePodPipelineGenerator(object):
                 "--env",
                 self.context.env,
                 "--params",
-                create_params(self.context.params.keys()),
+                create_params(
+                    self.context.params.keys(),
+                    {"kubeflow_run_id": dsl.RUN_ID_PLACEHOLDER}
+                    if is_mlflow_enabled()
+                    else {},
+                ),
                 "--pipeline",
                 pipeline,
             ],

--- a/kedro_kubeflow/generators/utils.py
+++ b/kedro_kubeflow/generators/utils.py
@@ -1,7 +1,7 @@
 import os
 from functools import wraps
 from inspect import Parameter, signature
-from typing import Dict, Iterable, Optional
+from typing import Iterable
 
 import kubernetes.client as k8s
 from kfp import dsl
@@ -26,15 +26,9 @@ def maybe_add_params(kedro_parameters):
     return decorator
 
 
-def create_params(
-    param_keys: Iterable[str],
-    fixed_value_params: Optional[Dict[str, str]] = None,
-) -> str:
-    if fixed_value_params is None:
-        fixed_value_params = {}
+def create_params(param_keys: Iterable[str]) -> str:
     return ",".join(
         [f"{param}:{dsl.PipelineParam(param)}" for param in param_keys]
-        + [f"{key}:{value}" for key, value in fixed_value_params.items()]
     )
 
 

--- a/kedro_kubeflow/generators/utils.py
+++ b/kedro_kubeflow/generators/utils.py
@@ -1,7 +1,7 @@
 import os
 from functools import wraps
 from inspect import Parameter, signature
-from typing import Iterable
+from typing import Dict, Iterable, Optional
 
 import kubernetes.client as k8s
 from kfp import dsl
@@ -26,9 +26,15 @@ def maybe_add_params(kedro_parameters):
     return decorator
 
 
-def create_params(param_keys: Iterable[str]) -> str:
+def create_params(
+    param_keys: Iterable[str],
+    fixed_value_params: Optional[Dict[str, str]] = None,
+) -> str:
+    if fixed_value_params is None:
+        fixed_value_params = {}
     return ",".join(
         [f"{param}:{dsl.PipelineParam(param)}" for param in param_keys]
+        + [f"{key}:{value}" for key, value in fixed_value_params.items()]
     )
 
 

--- a/kedro_kubeflow/generators/utils.py
+++ b/kedro_kubeflow/generators/utils.py
@@ -42,7 +42,8 @@ def create_container_environment():
     env_vars = [
         k8s.V1EnvVar(
             name=IAP_CLIENT_ID, value=os.environ.get(IAP_CLIENT_ID, "")
-        )
+        ),
+        k8s.V1EnvVar(name="KUBEFLOW_RUN_ID", value=dsl.RUN_ID_PLACEHOLDER),
     ]
     for key in os.environ.keys():
         if key.startswith("KEDRO_CONFIG_"):

--- a/kedro_kubeflow/hooks.py
+++ b/kedro_kubeflow/hooks.py
@@ -60,10 +60,7 @@ class MlflowTagsHook:
         if is_mlflow_enabled():
             import mlflow
 
-            if (
-                "KUBEFLOW_RUN_ID" in os.environ
-                and os.environ["KUBEFLOW_RUN_ID"]
-            ):
+            if os.getenv("KUBEFLOW_RUN_ID"):
                 mlflow.set_tag(
                     "kubeflow_run_id", os.environ["KUBEFLOW_RUN_ID"]
                 )

--- a/kedro_kubeflow/hooks.py
+++ b/kedro_kubeflow/hooks.py
@@ -56,7 +56,7 @@ class MlflowTagsHook:
     """Adds `kubeflow_run_id` to MLFlow tags based on environment variables"""
 
     @hook_impl
-    def after_pipeline_run(self) -> None:
+    def before_node_run(self) -> None:
         if is_mlflow_enabled():
             import mlflow
 

--- a/kedro_kubeflow/hooks.py
+++ b/kedro_kubeflow/hooks.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Iterable
+from typing import Dict, Iterable
 
 from kedro.config import ConfigLoader, TemplatedConfigLoader
 from kedro.framework.hooks import hook_impl
@@ -53,17 +53,19 @@ class MlflowIapAuthHook:
 
 
 class MlflowTagsHook:
-    """Adds `kubeflow_run_id` to MLFlow tags based on value passed from parameters"""
+    """Adds `kubeflow_run_id` to MLFlow tags based on environment variables"""
 
     @hook_impl
-    def after_pipeline_run(self, run_params: Dict[str, Any]) -> None:
+    def after_pipeline_run(self) -> None:
         if is_mlflow_enabled():
             import mlflow
 
-            if "kubeflow_run_id" in run_params["extra_params"]:
+            if (
+                "KUBEFLOW_RUN_ID" in os.environ
+                and os.environ["KUBEFLOW_RUN_ID"]
+            ):
                 mlflow.set_tag(
-                    "kubeflow_run_id",
-                    run_params["extra_params"]["kubeflow_run_id"],
+                    "kubeflow_run_id", os.environ["KUBEFLOW_RUN_ID"]
                 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "kedro.project_commands": ["kubeflow = kedro_kubeflow.cli:commands"],
         "kedro.hooks": [
             "kubeflow_cfg_hook = kedro_kubeflow.hooks:register_templated_config_loader",
+            "kubeflow_mlflow_tags_hook = kedro_kubeflow.hooks:mlflow_tags_hook",
         ],
     },
 )

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -150,10 +150,13 @@ class TestGenerator(unittest.TestCase):
             "{{workflow.uid}}",
         ]
         for node_name in ["node1", "node2"]:
-            env = dsl_pipeline.ops[node_name].container.env
-            assert env[1].name == "MLFLOW_RUN_ID"
+            env = {
+                e.name: e.value
+                for e in dsl_pipeline.ops[node_name].container.env
+            }
+            assert "MLFLOW_RUN_ID" in env
             assert (
-                env[1].value
+                env["MLFLOW_RUN_ID"]
                 == "{{pipelineparam:op=mlflow-start-run;name=mlflow_run_id}}"
             )
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -69,7 +69,7 @@ class TestMlflowIapAuthHook(unittest.TestCase):
 class TestMlflowTagsHook(unittest.TestCase):
     def test_should_set_mlflow_tags(self, mlflow_set_tag):
         with environment({"KUBEFLOW_RUN_ID": "KFP_123"}):
-            MlflowTagsHook().after_pipeline_run()
+            MlflowTagsHook().before_node_run()
 
         mlflow_set_tag.assert_called_with("kubeflow_run_id", "KFP_123")
 
@@ -77,7 +77,7 @@ class TestMlflowTagsHook(unittest.TestCase):
         self, mlflow_set_tag
     ):
         with environment({}, delete_keys=["KUBEFLOW_RUN_ID"]):
-            MlflowTagsHook().after_pipeline_run()
+            MlflowTagsHook().before_node_run()
 
         mlflow_set_tag.assert_not_called()
 
@@ -85,7 +85,7 @@ class TestMlflowTagsHook(unittest.TestCase):
         self, mlflow_set_tag
     ):
         with environment({"KUBEFLOW_RUN_ID": ""}):
-            MlflowTagsHook().after_pipeline_run()
+            MlflowTagsHook().before_node_run()
 
         mlflow_set_tag.assert_not_called()
 
@@ -104,7 +104,7 @@ class TestMlflowTagsHook(unittest.TestCase):
 
         # when
         with environment({"KUBEFLOW_RUN_ID": "KFP_123"}):
-            MlflowTagsHook().after_pipeline_run()
+            MlflowTagsHook().before_node_run()
 
         # then
         mlflow_set_tag.assert_not_called()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3,9 +3,14 @@ import unittest
 from contextlib import contextmanager
 from unittest.mock import patch
 
+import mlflow
+
 from kedro_kubeflow.auth import AuthHandler
-from kedro_kubeflow.hooks import MlflowIapAuthHook  # NOQA
-from kedro_kubeflow.hooks import RegisterTemplatedConfigLoaderHook
+from kedro_kubeflow.hooks import (  # NOQA
+    MlflowIapAuthHook,
+    MlflowTagsHook,
+    RegisterTemplatedConfigLoaderHook,
+)
 
 
 @contextmanager
@@ -53,3 +58,46 @@ class TestMlflowIapAuthHook(unittest.TestCase):
 
         assert os.environ["MLFLOW_TRACKING_TOKEN"] == "TEST_TOKEN"
         obtain_id_token.assert_called_with()
+
+
+@patch.object(mlflow, "set_tag")
+class TestMlflowTagsHook(unittest.TestCase):
+    def test_should_set_mlflow_tags(self, mlflow_set_tag):
+        MlflowTagsHook().after_pipeline_run(
+            run_params={"extra_params": {"kubeflow_run_id": "KFP_123"}}
+        )
+
+        mlflow_set_tag.assert_called_with("kubeflow_run_id", "KFP_123")
+
+    def test_should_not_set_mlflow_tags_when_kubeflow_run_id_is_not_passed_in_params(
+        self, mlflow_set_tag
+    ):
+        MlflowTagsHook().after_pipeline_run(
+            run_params={"extra_params": {"other_param": "value"}}
+        )
+
+        mlflow_set_tag.assert_not_called()
+
+    def test_should_not_set_mlflow_tags_when_mlflow_is_not_enabled(
+        self, mlflow_set_tag
+    ):
+        # given
+        real_import = __builtins__["__import__"]
+
+        def mlflow_import_disabled(name, *args, **kw):
+            if name == "mlflow":
+                raise ImportError
+            return real_import(name, *args, **kw)
+
+        __builtins__["__import__"] = mlflow_import_disabled
+
+        # when
+        MlflowTagsHook().after_pipeline_run(
+            run_params={"extra_params": {"kubeflow_run_id": "KFP_123"}}
+        )
+
+        # then
+        mlflow_set_tag.assert_not_called()
+
+        # cleanup
+        __builtins__["__import__"] = real_import

--- a/tests/test_one_pod_pipeline_generator.py
+++ b/tests/test_one_pod_pipeline_generator.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 
 import kfp
 from kedro.pipeline import Pipeline, node
-from kfp import dsl
 
 from kedro_kubeflow.config import PluginConfig
 from kedro_kubeflow.generators.one_pod_pipeline_generator import (
@@ -60,32 +59,6 @@ class TestGenerator(unittest.TestCase):
             "--params",
             "param1:{{pipelineparam:op=;name=param1}},"
             "param2:{{pipelineparam:op=;name=param2}}",
-            "--pipeline",
-            "pipeline",
-        ]
-
-    def test_should_inject_kubeflow_run_id_when_mlflow_is_enabled(self):
-        # given
-        self.create_generator(params={"param": 0.3})
-        self.mock_mlflow(True)
-
-        # when
-        with kfp.dsl.Pipeline(None) as dsl_pipeline:
-            pipeline = self.generator_under_test.generate_pipeline(
-                "pipeline", "unittest-image", "Always"
-            )
-            default_params = signature(pipeline).parameters
-            pipeline()
-
-        # then
-        assert default_params["param"].default == 0.3
-        assert dsl_pipeline.ops["pipeline"].container.args == [
-            "run",
-            "--env",
-            "unittests",
-            "--params",
-            "param:{{pipelineparam:op=;name=param}},"
-            f"kubeflow_run_id:{dsl.RUN_ID_PLACEHOLDER}",
             "--pipeline",
             "pipeline",
         ]
@@ -255,18 +228,3 @@ class TestGenerator(unittest.TestCase):
             project_name="my-awesome-project",
             context=context,
         )
-
-    def mock_mlflow(self, enabled=False):
-        def fakeimport(name, *args, **kw):
-            if not enabled and name == "mlflow":
-                raise ImportError
-            return self.realimport(name, *args, **kw)
-
-        __builtins__["__import__"] = fakeimport
-
-    def setUp(self):
-        self.realimport = __builtins__["__import__"]
-        self.mock_mlflow(False)
-
-    def tearDown(self):
-        __builtins__["__import__"] = self.realimport


### PR DESCRIPTION
#### Description

`kubeflow_run_id` is used to correlate MLFlow run with a Kubeflow pipeline execution. In this fix the parameter is explicitly passed in `--params` to `kedro` command when `full` node merge strategy is chosen and MLFlow is enabled.

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
