### PR TITLE
Pass params using config.yaml

### DIFF
--- a/kedro_kubeflow/generators/one_pod_pipeline_generator.py
+++ b/kedro_kubeflow/generators/one_pod_pipeline_generator.py
@@ -5,8 +5,9 @@ from kfp import dsl
 
 from ..utils import clean_name
 from .utils import (
+    create_arguments_from_parameters,
+    create_command_using_params_dumper,
     create_container_environment,
-    create_params,
     maybe_add_params,
 )
 
@@ -50,16 +51,16 @@ class OnePodPipelineGenerator(object):
         container_op = dsl.ContainerOp(
             name=clean_name(pipeline),
             image=image,
-            command=["kedro"],
-            arguments=[
-                "run",
-                "--env",
-                self.context.env,
-                "--params",
-                create_params(self.context.params.keys()),
-                "--pipeline",
-                pipeline,
-            ],
+            command=create_command_using_params_dumper(
+                "kedro "
+                "run "
+                f"--env {self.context.env} "
+                f"--pipeline {pipeline} "
+                f"--config config.yaml"
+            ),
+            arguments=create_arguments_from_parameters(
+                self.context.params.keys()
+            ),
             container_kwargs=kwargs,
             file_outputs={
                 output: f"/home/kedro/{self.catalog[output]['filepath']}"

--- a/kedro_kubeflow/generators/utils.py
+++ b/kedro_kubeflow/generators/utils.py
@@ -55,9 +55,8 @@ def create_command_using_params_dumper(command):
         "python -c 'import yaml, sys;"
         "load=lambda e: yaml.load(e, Loader=yaml.FullLoader);"
         "params=dict(zip(sys.argv[1::2], [load(e) for e in sys.argv[2::2]]));"
-        'content={"run": {"params": params}};'
-        'with open("config.yaml") as f: yaml.dump(content, f)\' "$@" && '
-        + command,
+        'f=open("config.yaml", "w");'
+        'yaml.dump({"run": {"params": params}}, f)\' "$@" &&' + command,
     ]
 
 

--- a/kedro_kubeflow/generators/utils.py
+++ b/kedro_kubeflow/generators/utils.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 from functools import wraps
 from inspect import Parameter, signature
@@ -27,6 +28,7 @@ def maybe_add_params(kedro_parameters):
 
 
 def create_params(param_keys: Iterable[str]) -> str:
+    return ""
     return ",".join(
         [f"{param}:{dsl.PipelineParam(param)}" for param in param_keys]
     )
@@ -44,3 +46,24 @@ def create_container_environment():
             env_vars.append(k8s.V1EnvVar(name=key, value=os.environ[key]))
 
     return env_vars
+
+
+def create_command_using_params_dumper(command):
+    return [
+        "bash",
+        "-c",
+        "python -c 'import yaml, sys;"
+        "load=lambda e: yaml.load(e, Loader=yaml.FullLoader);"
+        "params=dict(zip(sys.argv[1::2], [load(e) for e in sys.argv[2::2]]));"
+        'content={"run": {"params": params}};'
+        'with open("config.yaml") as f: yaml.dump(content, f)\' "$@" && '
+        + command,
+    ]
+
+
+def create_arguments_from_parameters(paramter_names):
+    return ["_"] + list(
+        itertools.chain(
+            *[[param, dsl.PipelineParam(param)] for param in paramter_names]
+        )
+    )


### PR DESCRIPTION
#### Description

Instead of passing parameters using `--params`, the container now creates a `config.yaml` file as decribed in https://kedro.readthedocs.io/en/stable/04_kedro_project_setup/02_configuration.html#configure-kedro-run-arguments

Resolves #60 

##### PR Checklist
- [ ] Tests added
- [ ] [Changelog](CHANGELOG.md) updated 
