### PR TITLE
Add pipeline name when uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Kedro pipeline name is now added into Kubeflow pipeline name during upload
+
 ## [0.5.1] - 2022-01-28
 
 -   Possibility to run custom Kedro pipeline as on-exit-handler

--- a/kedro_kubeflow/cli.py
+++ b/kedro_kubeflow/cli.py
@@ -165,7 +165,7 @@ def upload_pipeline(ctx, image, pipeline) -> None:
     config = context_helper.config.run_config
 
     context_helper.kfp_client.upload(
-        pipeline=pipeline,
+        pipeline_name=pipeline,
         image=image if image else config.image,
         image_pull_policy=config.image_pull_policy,
     )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 INSTALL_REQUIRES = [
     "kedro>=0.16,<=0.18",
     "click<8.0",
-    "kfp~=1.6.0",
+    "kfp~=1.8.0",
     "tabulate>=0.8.7",
     "semver~=2.10",
     "google-auth<2.0dev",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     keywords="kedro kubeflow plugin",
-    author=u"Mateusz Pytel, Mariusz Strzelecki",
+    author="Mateusz Pytel, Mariusz Strzelecki",
     author_email="mateusz@getindata.com",
     url="https://github.com/getindata/kedro-kubeflow/",
     packages=find_packages(exclude=["ez_setup", "examples", "tests", "docs"]),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,7 +127,7 @@ class TestPluginCLI(unittest.TestCase):
 
         assert result.exit_code == 0
         context_helper.kfp_client.upload.assert_called_with(
-            image="img", image_pull_policy="Always", pipeline="pipe"
+            image="img", image_pull_policy="Always", pipeline_name="pipe"
         )
 
     def test_schedule(self):

--- a/tests/test_kfpclient.py
+++ b/tests/test_kfpclient.py
@@ -221,10 +221,7 @@ class TestKubeflowClient(unittest.TestCase):
         self.kfp_client_mock.get_experiment.return_value = (
             self.create_experiment()
         )
-        self.kfp_client_mock.pipelines = unittest.mock.MagicMock()
-        self.kfp_client_mock.pipelines.list_pipelines.return_value = (
-            self.create_pipelines_list()
-        )
+        self.kfp_client_mock.get_pipeline_id.return_value = "someid"
 
         # when
         self.client_under_test.schedule(
@@ -254,10 +251,7 @@ class TestKubeflowClient(unittest.TestCase):
         self.kfp_client_mock.create_experiment.return_value = (
             self.create_experiment()
         )
-        self.kfp_client_mock.pipelines = unittest.mock.MagicMock()
-        self.kfp_client_mock.pipelines.list_pipelines.return_value = (
-            self.create_pipelines_list()
-        )
+        self.kfp_client_mock.get_pipeline_id.return_value = "someid"
 
         # when
         self.client_under_test.schedule(
@@ -284,10 +278,7 @@ class TestKubeflowClient(unittest.TestCase):
         self.kfp_client_mock.get_experiment.return_value = (
             self.create_experiment()
         )
-        self.kfp_client_mock.pipelines = unittest.mock.MagicMock()
-        self.kfp_client_mock.pipelines.list_pipelines.return_value = (
-            self.create_pipelines_list()
-        )
+        self.kfp_client_mock.get_pipeline_id.return_value = "someid"
         self.kfp_client_mock.list_recurring_runs.return_value = (
             self.create_recurring_jobs_list("scheduled run for region ABC")
         )
@@ -317,14 +308,11 @@ class TestKubeflowClient(unittest.TestCase):
     def test_should_upload_new_pipeline(self):
         # given
         self.create_client({"description": "Very Important Pipeline"})
-        self.kfp_client_mock.pipelines = unittest.mock.MagicMock()
-        self.kfp_client_mock.pipelines.list_pipelines.return_value = (
-            self.create_empty_pipelines_list()
-        )
+        self.kfp_client_mock.get_pipeline_id.return_value = None
 
         # when
         self.client_under_test.upload(
-            pipeline="pipeline",
+            pipeline_name="pipeline_name",
             image="unittest-image",
             image_pull_policy="Always",
         )
@@ -336,20 +324,16 @@ class TestKubeflowClient(unittest.TestCase):
             args,
             kwargs,
         ) = self.kfp_client_mock.pipeline_uploads.upload_pipeline.call_args
-        assert kwargs["name"] == "my-awesome-project"
+        assert kwargs["name"] == "[my-awesome-project] pipeline_name"
         assert kwargs["description"] == "Very Important Pipeline"
 
     def test_should_upload_new_version_of_existing_pipeline(self):
         # given
-        self.kfp_client_mock.pipelines = unittest.mock.MagicMock()
-        self.kfp_client_mock.pipelines = unittest.mock.MagicMock()
-        self.kfp_client_mock.pipelines.list_pipelines.return_value = (
-            self.create_pipelines_list()
-        )
+        self.kfp_client_mock.get_pipeline_id.return_value = "123"
 
         # when
         self.client_under_test.upload(
-            pipeline="pipeline",
+            pipeline_name="pipeline",
             image="unittest-image",
             image_pull_policy="Always",
         )


### PR DESCRIPTION
#### Description

Pipeline name was missing in Kubeflow interface, so we couldn't differentiate two pipelines from one project. It's fixed by using the template `[kedro_project_name] pipeline_name`.

Also, KFP client is bumped to 1.8

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
