### PR TITLE
Fix being able to use `global.yml` without DISABLE_HOOKS_FOR_PLUGINS

### DIFF
--- a/kedro_kubeflow/hooks.py
+++ b/kedro_kubeflow/hooks.py
@@ -36,6 +36,7 @@ class RegisterTemplatedConfigLoaderHook:
     ) -> ConfigLoader:
         return TemplatedConfigLoader(
             conf_paths,
+            globals_pattern="*globals.yml",
             globals_dict=self.read_env(),
         )
 


### PR DESCRIPTION
#### Description

Purpose of the PR:
Changed to use `global.yml` without adding kedro-docker to DISABLE_HOOKS_FOR_PLUGINS. In addition, global parameters with environment variables using `KEDRO_CONFIG_` will work at the same time with this change.
 
Will resolved issue:
https://github.com/getindata/kedro-kubeflow/issues/72

##### PR Checklist
- [x] Tests added
- [ ] [Changelog](CHANGELOG.md) updated 
