### PR TITLE
Stringify params that are not json-serializable

### DIFF
--- a/tests/test_one_pod_pipeline_generator.py
+++ b/tests/test_one_pod_pipeline_generator.py
@@ -1,5 +1,6 @@
 """Test generator"""
 
+import datetime
 import os
 import unittest
 from inspect import signature
@@ -38,7 +39,13 @@ class TestGenerator(unittest.TestCase):
 
     def test_should_support_params_and_inject_them_to_the_node(self):
         # given
-        self.create_generator(params={"param1": 0.3, "param2": 42})
+        self.create_generator(
+            params={
+                "param1": 0.3,
+                "param2": 42,
+                "param3": datetime.date(2022, 2, 24),
+            }
+        )
 
         # when
         with kfp.dsl.Pipeline(None) as dsl_pipeline:
@@ -49,14 +56,18 @@ class TestGenerator(unittest.TestCase):
             pipeline()
 
         # then
-        assert len(default_params) == 2
+        print(default_params)
+        assert len(default_params) == 3
         assert default_params["param1"].default == 0.3
         assert default_params["param2"].default == 42
+        assert default_params["param3"].default == "2022-02-24"
         assert dsl_pipeline.ops["pipeline"].container.args[1:] == [
             "param1",
             "{{pipelineparam:op=;name=param1}}",
             "param2",
             "{{pipelineparam:op=;name=param2}}",
+            "param3",
+            "{{pipelineparam:op=;name=param3}}",
         ]
 
     def test_should_not_add_resources_spec_if_not_requested(self):


### PR DESCRIPTION
#### Description

Kedro loads strings that look like YYYY-MM-DD as datetimes and these objects are not serializable to pipeline definition. This PR ensures they are stringified.

Resolves #88 

##### PR Checklist
- [x] Tests added
- [ ] [Changelog](CHANGELOG.md) updated 
