### PR TITLE
Retry policy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Added support for defining retry policy for the Kubeflow Pipelines nodes
+
 ## [0.6.1] - 2022-03-07
 
 -   Fixed support for parameters of type `datetime.date`

--- a/kedro_kubeflow/generators/pod_per_node_pipeline_generator.py
+++ b/kedro_kubeflow/generators/pod_per_node_pipeline_generator.py
@@ -114,13 +114,6 @@ class PodPerNodePipelineGenerator(object):
 
         for node in node_dependencies:
             name = clean_name(node.name)
-            kwargs = {"env": nodes_env}
-            if self.run_config.resources.is_set_for(node.name):
-                kwargs["resources"] = k8s.V1ResourceRequirements(
-                    limits=self.run_config.resources.get_for(node.name),
-                    requests=self.run_config.resources.get_for(node.name),
-                )
-
             kfp_ops[node.name] = customize_op(
                 dsl.ContainerOp(
                     name=name,
@@ -137,7 +130,7 @@ class PodPerNodePipelineGenerator(object):
                         self.context.params.keys()
                     ),
                     pvolumes=node_volumes,
-                    container_kwargs=kwargs,
+                    container_kwargs={"env": nodes_env},
                     file_outputs={
                         output: "/home/kedro/"
                         + self.catalog[output]["filepath"]

--- a/kedro_kubeflow/generators/utils.py
+++ b/kedro_kubeflow/generators/utils.py
@@ -127,4 +127,14 @@ def customize_op(op, image_pull_policy, run_config):
         op.container.set_security_context(
             k8s.V1SecurityContext(run_as_user=run_config.volume.owner)
         )
+
+    if run_config.resources.is_set_for(op.name):
+        op.container.resources = k8s.V1ResourceRequirements(
+            limits=run_config.resources.get_for(op.name),
+            requests=run_config.resources.get_for(op.name),
+        )
+    if run_config.retry_policy.is_set_for(op.name):
+        op.set_retry(
+            policy="Always", **run_config.retry_policy.get_for(op.name)
+        )
     return op

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -130,3 +130,35 @@ class TestPluginConfig(unittest.TestCase):
         cfg = PluginConfig({"run_config": {"run_name": "some run"}})
         assert cfg.run_config.run_name == "some run"
         assert cfg.run_config.scheduled_run_name == "some run"
+
+    def test_retry_policy_default_and_node_specific(self):
+        cfg = PluginConfig(
+            {
+                "run_config": {
+                    "retry_policy": {
+                        "__default__": {
+                            "num_retries": 4,
+                            "backoff_duration": "60s",
+                            "backoff_factor": 2,
+                        },
+                        "node3": {
+                            "num_retries": "100",
+                            "backoff_duration": "5m",
+                            "backoff_factor": 1,
+                        },
+                    }
+                }
+            }
+        )
+        assert cfg.run_config.retry_policy.is_set_for("node2")
+        assert cfg.run_config.retry_policy.get_for("node2") == {
+            "backoff_duration": "60s",
+            "backoff_factor": 2,
+            "num_retries": 4,
+        }
+        assert cfg.run_config.retry_policy.is_set_for("node3")
+        assert cfg.run_config.retry_policy.get_for("node3") == {
+            "backoff_duration": "5m",
+            "backoff_factor": 1,
+            "num_retries": 100,
+        }

--- a/tests/test_one_pod_pipeline_generator.py
+++ b/tests/test_one_pod_pipeline_generator.py
@@ -104,6 +104,57 @@ class TestGenerator(unittest.TestCase):
         assert resources.limits == {"cpu": "100m", "memory": "8Gi"}
         assert resources.requests == {"cpu": "100m", "memory": "8Gi"}
 
+    def test_should_not_add_retry_policy_if_not_requested(self):
+        # given
+        self.create_generator(config={})
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )()
+
+        # then
+        op = dsl_pipeline.ops["pipeline"]
+        assert op.num_retries == 0
+        assert op.retry_policy is None
+        assert op.backoff_factor is None
+        assert op.backoff_duration is None
+        assert op.backoff_max_duration is None
+
+    def test_should_add_retry_policy(self):
+        # given
+        self.create_generator(
+            config={
+                "retry_policy": {
+                    "__default__": {
+                        "num_retries": 4,
+                        "backoff_duration": "60s",
+                        "backoff_factor": 2,
+                    },
+                    "node1": {
+                        "num_retries": 100,
+                        "backoff_duration": "5m",
+                        "backoff_factor": 1,
+                    },
+                }
+            }
+        )
+
+        # when
+        with kfp.dsl.Pipeline(None) as dsl_pipeline:
+            self.generator_under_test.generate_pipeline(
+                "pipeline", "unittest-image", "Always"
+            )()
+
+        # then
+        op = dsl_pipeline.ops["pipeline"]
+        assert op.num_retries == 4
+        assert op.retry_policy == "Always"
+        assert op.backoff_factor == 2
+        assert op.backoff_duration == "60s"
+        assert op.backoff_max_duration is None
+
     def test_should_set_description(self):
         # given
         self.create_generator(config={"description": "DESC"})


### PR DESCRIPTION
#### Description

This PR brings support of retry policy into pipeline definition. It is controlled via configuration file in the same way how CPU/MEM resources are handled -> with overrideable `__defaults__`.

This feature is super useful in autoscalable Kubernetes clusters, where the pods may be evicted if the autoscaler decides to... 
![image](https://user-images.githubusercontent.com/4659069/157488972-489e4407-5feb-4c5d-a193-43d2a9b8ff3f.png)

But, it can be useful to provide functionality similar to Airflow's Sensors in "reschedule" mode

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 