### PR TITLE
Use KFP 1.8.11 to fix TTL issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 INSTALL_REQUIRES = [
     "kedro>=0.16,<=0.18",
     "click<8.0",
-    "kfp~=1.8.0",
+    "kfp>=1.8.11,<2.0",
     "tabulate>=0.8.7",
     "semver~=2.10",
     "google-auth<2.0dev",


### PR DESCRIPTION
#### Description

TTL support for pipelines is broken in KFP<1.8.11. The issue was noticed in October 2021: https://github.com/kubeflow/pipelines/pull/6801, but the fix was not merged. Thankfully, another fix was submitted: https://github.com/kubeflow/pipelines/pull/7141 and merged, released as 1.8.11: https://github.com/kubeflow/pipelines/blob/master/sdk/RELEASE.md#1811

This PR also makes sure that 2.0 version will not be used, as it's not compatible with the plugin (still alpha though):

```
$ kedro kubeflow compile
...
  File "/opt/conda/envs/python38/lib/python3.8/site-packages/kedro_kubeflow/generators/utils.py", line 10, in <module>
    from kfp.compiler._k8s_helper import sanitize_k8s_name
ModuleNotFoundError: No module named 'kfp.compiler._k8s_helper'
```

##### PR Checklist
- [ ] Tests added
- [ ] [Changelog](CHANGELOG.md) updated 
