### PR TITLE
Feature/219 support namespaces in params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 -  Removed field validation from resources configuration field - now it can take any custom parameters such as "nvidia.com/gpu":1
+-  Added support for kedro namespaces for parameters
 
 ## [0.7.3] - 2022-09-23
 

--- a/tests/test_generator_utils.py
+++ b/tests/test_generator_utils.py
@@ -2,7 +2,10 @@
 
 import unittest
 
-from kedro_kubeflow.generators.utils import is_local_fs
+from kedro_kubeflow.generators.utils import (
+    is_local_fs,
+    merge_namespaced_params_to_dict,
+)
 
 
 def gcsfs_is_missing():
@@ -19,3 +22,34 @@ class TestGeneratorUtils(unittest.TestCase):
     def test_is_local(self):
         assert is_local_fs("data/test/file.txt") is True
         assert is_local_fs("gs://test-bucket/file.txt") is False
+
+    def test_namespaced_params_merged_into_dict_properly(self):
+        # given
+        params = {
+            "outer_namespace.inner_namespace1.param1": "outer_namespace.inner_namespace1.param1_v",
+            "outer_namespace.inner_namespace1.param2": "outer_namespace.inner_namespace1.param2_v",
+            "outer_namespace.inner_namespace2.param1": "outer_namespace.inner_namespace2.param1_v",
+            "outer_namespace.inner_namespace2.param2": "outer_namespace.inner_namespace2.param2_v",
+            "outer_namespace.param": "outer_namespace.param",
+            "param1": 42,
+        }
+
+        # when
+        result = merge_namespaced_params_to_dict(params)
+
+        # expect
+        expected = {
+            "outer_namespace": {
+                "inner_namespace1": {
+                    "param1": "outer_namespace.inner_namespace1.param1_v",
+                    "param2": "outer_namespace.inner_namespace1.param2_v",
+                },
+                "inner_namespace2": {
+                    "param1": "outer_namespace.inner_namespace2.param1_v",
+                    "param2": "outer_namespace.inner_namespace2.param2_v",
+                },
+                "param": "outer_namespace.param",
+            },
+            "param1": 42,
+        }
+        assert result == expected

--- a/tests/test_pod_per_node_pipeline_generator.py
+++ b/tests/test_pod_per_node_pipeline_generator.py
@@ -318,6 +318,90 @@ class TestGenerator(unittest.TestCase, MinimalConfigMixin):
                     ],
                 )
 
+    def test_should_support_nested_params_and_inject_them_to_the_node(self):
+        # given
+        self.create_generator(
+            params={
+                "param1": {"nested1": {"nested2": 1, "nested3": 2}},
+                "param2": 42,
+            }
+        )
+
+        # when
+        with patch(
+            "kedro.framework.project.pipelines",
+            new=self.pipelines_under_test,
+        ):
+            with kfp.dsl.Pipeline(None) as dsl_pipeline:
+                pipeline = self.generator_under_test.generate_pipeline(
+                    "pipeline", "unittest-image", "Always"
+                )
+                default_params = signature(pipeline).parameters
+                pipeline()
+
+            # then
+            assert len(default_params) == 2
+            assert default_params["param1"].default == {
+                "nested1": {"nested2": 1, "nested3": 2}
+            }
+            assert default_params["param2"].default == 42
+            for node_name in ["node1", "node2", "node3"]:
+                assert dsl_pipeline.ops[node_name].container.args[1:] == [
+                    "param1",
+                    "{{pipelineparam:op=;name=param1}}",
+                    "param2",
+                    "{{pipelineparam:op=;name=param2}}",
+                ]
+
+    def test_should_support_namespaced_params_and_inject_them_to_the_node(
+        self,
+    ):
+        # given
+        self.create_generator(
+            params={
+                "outer_namespace.inner_namespace1.param1": "outer_namespace.inner_namespace1.param1_v",
+                "outer_namespace.inner_namespace1.param2": "outer_namespace.inner_namespace1.param2_v",
+                "outer_namespace.inner_namespace2.param1": "outer_namespace.inner_namespace2.param1_v",
+                "outer_namespace.inner_namespace2.param2": "outer_namespace.inner_namespace2.param2_v",
+                "outer_namespace.param": "outer_namespace.param",
+                "param1": 42,
+            }
+        )
+
+        # when
+        with patch(
+            "kedro.framework.project.pipelines",
+            new=self.pipelines_under_test,
+        ):
+            with kfp.dsl.Pipeline(None) as dsl_pipeline:
+                pipeline = self.generator_under_test.generate_pipeline(
+                    "pipeline", "unittest-image", "Always"
+                )
+                default_params = signature(pipeline).parameters
+                pipeline()
+
+            # then
+            assert len(default_params) == 2
+            assert default_params["outer_namespace"].default == {
+                "inner_namespace1": {
+                    "param1": "outer_namespace.inner_namespace1.param1_v",
+                    "param2": "outer_namespace.inner_namespace1.param2_v",
+                },
+                "inner_namespace2": {
+                    "param1": "outer_namespace.inner_namespace2.param1_v",
+                    "param2": "outer_namespace.inner_namespace2.param2_v",
+                },
+                "param": "outer_namespace.param",
+            }
+            assert default_params["param1"].default == 42
+            for node_name in ["node1", "node2", "node3"]:
+                assert dsl_pipeline.ops[node_name].container.args[1:] == [
+                    "outer_namespace",
+                    "{{pipelineparam:op=;name=outer_namespace}}",
+                    "param1",
+                    "{{pipelineparam:op=;name=param1}}",
+                ]
+
     def test_should_fallbackto_default_resources_spec_if_not_requested(self):
         # given
         self.create_generator(config={})


### PR DESCRIPTION
Now params which defined as `outer_namespace.inner_namespace.param_name` are converted to the following structure before adding to the pipeline:

```json
{
  "outer_namespace": {
      "inner_namespace": {
        "param_name": "value",
        ...
      },
      "another_inner_namespace": {
        "param_name": "value"
        ...
      }
  }
}
```

#### Description

`describe the purpose of the change here` 

Resolves https://github.com/getindata/kedro-kubeflow/issues/219

##### PR Checklist
- [X] Tests added
- [X] [Changelog](CHANGELOG.md) updated 
