### PR TITLE
Bumped GitHub spellcheck action to latest version: 0.35.0

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,5 +16,5 @@ jobs:
     steps:
       # Spellcheck
       - uses: actions/checkout@v2
-      - uses: rojopolis/spellcheck-github-actions@0.25.0
+      - uses: rojopolis/spellcheck-github-actions@0.35.0
         name: Spellcheck


### PR DESCRIPTION
#### Description

Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am sunsetting version 0.25.0 as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to version 0.35.0, so this PR offers an update to the latest version.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can see your are using [Dependabot](https://github.com/dependabot). You can configure it to  keep your GitHub actions up to date.

```yaml
  # Enable version updates for Actions
  - package-ecosystem: "github-actions"
    # Look for `.github/workflows` in the `root` directory
    directory: "/"
    # Check for updates once a week
    schedule:
      interval: "weekly"
```

jonasbn

##### PR Checklist
- [ ] Tests added
- [ ] [Changelog](CHANGELOG.md) updated 
